### PR TITLE
hooks -> install-hooks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -66,7 +66,7 @@ venv:
 requirements: venv
 	$(requirements)
 
-hooks:
+install-hooks:
 	$(hooks)
 
 upstream:
@@ -87,7 +87,7 @@ test: init-essential
 commit-info:
 	$(commit-info)
 
-init: init-essential hooks upstream
+init: init-essential install-hooks upstream
 init-essential: requirements settings
 
 help:


### PR DESCRIPTION
We have a directory named hooks in the root directory. If this directory exists, then hooks target is not rebuild.

@kmerenkov 
